### PR TITLE
chore: fix CI typecheck and slim GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,17 +1,26 @@
 version: 2
 updates:
-    # Enable version updates for npm
+    # npm / pnpm dependencies
     - package-ecosystem: "npm"
-      # Look for `package.json` and `lock` files in the `root` directory
       directory: "/"
-      # Check for updates to GitHub Actions once a week
       schedule:
-          interval: "weekly"
-      target-branch: "dev"
+          interval: "monthly"
+      target-branch: "main"
+      open-pull-requests-limit: 5
+      groups:
+          production-dependencies:
+              dependency-type: "production"
+          development-dependencies:
+              dependency-type: "development"
 
-    # Enable version updates for Github Actions
+    # GitHub Actions
     - package-ecosystem: "github-actions"
       directory: "/"
       schedule:
-          # Check for updates to GitHub Actions once a week
-          interval: "weekly"
+          interval: "monthly"
+      target-branch: "main"
+      open-pull-requests-limit: 5
+      groups:
+          github-actions:
+              patterns:
+                  - "*"

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,7 @@
-# what?
+## What
 
-# why?
+<!-- Short summary of the change -->
+
+## Why
+
+<!-- Motivation / context -->

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,35 +1,38 @@
 name: CI
-on: push
+
+on:
+    push:
+    pull_request:
+
+concurrency:
+    group: ci-${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
+
 jobs:
     test:
         name: Lint, typecheck
         runs-on: ubuntu-latest
+        timeout-minutes: 10
         steps:
             - name: Checkout
-              uses: actions/checkout@v5
-            - name: Setup Node
-              uses: actions/setup-node@v4.0.1
-              with:
-                  node-version: "20"
+              uses: actions/checkout@v7
+
             - name: Setup pnpm
-              uses: pnpm/action-setup@v4
+              uses: pnpm/action-setup@v6
               with:
                   run_install: false
-            - name: Get pnpm store directory
-              shell: bash
-              run: |
-                  echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
-            - name: Setup pnpm cache
-              uses: actions/cache@v3
+
+            - name: Setup Node
+              uses: actions/setup-node@v7
               with:
-                  path: ${{ env.STORE_PATH }}
-                  key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
-                  restore-keys: |
-                      ${{ runner.os }}-pnpm-store-
-            # Throw an error if the pnpm-lock.yaml file doesn't match the installed dependencies
+                  node-version: "22"
+                  cache: "pnpm"
+
             - name: Install dependencies
               run: pnpm install --frozen-lockfile
+
             - name: Lint
               run: pnpm lint
+
             - name: Typecheck
               run: pnpm tsc --noEmit

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,21 +1,13 @@
 import type { AppProps } from "next/app";
 import { ThemeProvider } from "styled-components";
 import GlobalStyle from "@/components/globalstyles";
-import { theme, noto } from "@/config/theme";
+import { theme } from "@/config/theme";
 
 export default function App({ Component, pageProps }: AppProps) {
     return (
-        <>
-            {/* Early font-family to reduce FOUC; GlobalStyle (below) also sets it from theme.typography.fontFamily */}
-            <style jsx global>{`
-                html {
-                    font-family: ${noto.style.fontFamily};
-                }
-            `}</style>
-            <ThemeProvider theme={theme}>
-                <GlobalStyle />
-                <Component {...pageProps} />
-            </ThemeProvider>
-        </>
+        <ThemeProvider theme={theme}>
+            <GlobalStyle />
+            <Component {...pageProps} />
+        </ThemeProvider>
     );
 }

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -1,6 +1,7 @@
 import Document, { DocumentContext, Html, Head, Main, NextScript } from "next/document";
 import { ServerStyleSheet } from "styled-components";
 import { AppProps } from "next/app";
+import { noto } from "@/config/theme";
 
 export default class MyDocument extends Document {
     static async getInitialProps(ctx: DocumentContext) {
@@ -27,7 +28,8 @@ export default class MyDocument extends Document {
         return (
             <Html lang="en">
                 <Head />
-                <body>
+                {/* next/font class on body avoids FOUC without styled-jsx */}
+                <body className={noto.className}>
                     <Main />
                     <NextScript />
                 </body>


### PR DESCRIPTION
## Summary
- **Fix CI failure** ([run 29707570742](https://github.com/ThatAlexPalmer/palmer.earth/actions/runs/29707570742)): TypeScript rejected `styled-jsx` (`jsx`/`global` on `<style>`). Removed it; apply `next/font` via `body className` in `_document.tsx` instead (same FOUC goal, no extra types).
- **Modernize CI** (`.github/workflows/main.yml`):
  - `actions/checkout@v7`, `pnpm/action-setup@v6`, `actions/setup-node@v7`
  - Node **22** (Node 20 deprecated on runners)
  - Built-in `cache: pnpm` (drops separate `actions/cache`)
  - Concurrency cancel-in-progress + timeout
  - Triggers on `push` and `pull_request`
- **Dependabot**: retarget from nonexistent `dev` → `main`, monthly schedule, group related updates
- **CodeQL**: default setup set to `not-configured` (overkill for a personal brochure site)
- Closed stale Dependabot PRs #221–#232 (superseded)

## Audit notes
| Item | Action |
|------|--------|
| `workflows/main.yml` | Keep + update (only needed workflow) |
| CodeQL (GitHub default) | Disabled |
| Dependabot npm + actions | Keep, fixed target branch |
| PR template | Minimal what/why |

## Test plan
- [x] `pnpm lint` + `pnpm tsc --noEmit` locally
- [x] CI green on this PR