### PR TITLE
fix(products): keep status tags on the name line on mobile

### DIFF
--- a/src/components/ProductRow.tsx
+++ b/src/components/ProductRow.tsx
@@ -1,13 +1,15 @@
-import { ProductItem, RowText, RowTitle, StatusBadge } from "@/components/ui";
+import { ProductHeading, ProductItem, RowText, RowTitle, StatusBadge } from "@/components/ui";
 import type { Product } from "@/data/products";
 
 export default function ProductRow({ product }: { product: Product }) {
     return (
         <ProductItem>
-            <RowTitle href={product.href} target="_blank" rel="noopener noreferrer">
-                {product.name}
-            </RowTitle>
-            <StatusBadge $kind={product.status}>{product.status}</StatusBadge>
+            <ProductHeading>
+                <RowTitle href={product.href} target="_blank" rel="noopener noreferrer">
+                    {product.name}
+                </RowTitle>
+                <StatusBadge $kind={product.status}>{product.status}</StatusBadge>
+            </ProductHeading>
             <RowText>{product.blurb}</RowText>
         </ProductItem>
     );

--- a/src/components/ui/chrome.tsx
+++ b/src/components/ui/chrome.tsx
@@ -19,6 +19,8 @@ const hudFlicker = keyframes`
 
 const StatusBadge = styled.span<{ $kind: StatusKind }>`
     align-self: center;
+    justify-self: start;
+    width: max-content;
     padding: 2px ${({ theme }) => theme.space(2)};
     border: 1px solid ${({ theme, $kind }) => theme.colors.statusEdge[$kind]};
     font-family: ${({ theme }) => theme.typography.monoFont};

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -1,4 +1,4 @@
 export { Shell, Nav, Main, Hero, Section, Prose, Footer } from "./layout";
 export { H1, H2, RedBlock, SectionLabel, P, Stat } from "./typography";
-export { ProductList, PostList, ProductItem, PostItem, RowTitle, RowText, RowMetaBar, RowMeta } from "./lists";
+export { ProductList, PostList, ProductItem, ProductHeading, PostItem, RowTitle, RowText, RowMetaBar, RowMeta } from "./lists";
 export { StatusBadge, MoreLink, type StatusKind } from "./chrome";

--- a/src/components/ui/lists.tsx
+++ b/src/components/ui/lists.tsx
@@ -26,8 +26,10 @@ const ProductItem = styled.li`
     align-items: baseline;
 
     @media (max-width: ${({ theme }) => theme.breakpoints.phone}) {
-        grid-template-columns: 1fr;
-        gap: ${({ theme }) => theme.space(1)};
+        grid-template-columns: max-content max-content;
+        justify-content: start;
+        column-gap: ${({ theme }) => theme.space(2)};
+        row-gap: ${({ theme }) => theme.space(1)};
     }
 `;
 

--- a/src/components/ui/lists.tsx
+++ b/src/components/ui/lists.tsx
@@ -20,16 +20,28 @@ const rowChrome = css`
 
 const ProductItem = styled.li`
     ${rowChrome}
-    display: grid;
-    grid-template-columns: minmax(0, 1fr) auto;
-    gap: ${({ theme }) => theme.space(2)} ${({ theme }) => theme.space(4)};
-    align-items: baseline;
+    display: flex;
+    flex-direction: column;
+    gap: ${({ theme }) => theme.space(2)};
 
     @media (max-width: ${({ theme }) => theme.breakpoints.phone}) {
-        grid-template-columns: max-content max-content;
-        justify-content: start;
-        column-gap: ${({ theme }) => theme.space(2)};
-        row-gap: ${({ theme }) => theme.space(1)};
+        gap: ${({ theme }) => theme.space(1)};
+    }
+`;
+
+const ProductHeading = styled.div`
+    display: flex;
+    flex-wrap: nowrap;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: ${({ theme }) => theme.space(2)} ${({ theme }) => theme.space(4)};
+    width: 100%;
+
+    @media (max-width: ${({ theme }) => theme.breakpoints.phone}) {
+        justify-content: flex-start;
+        width: max-content;
+        max-width: 100%;
+        gap: ${({ theme }) => theme.space(2)};
     }
 `;
 
@@ -91,4 +103,4 @@ const RowMeta = styled.span`
     color: ${({ theme }) => theme.colors.g68};
 `;
 
-export { ProductList, PostList, ProductItem, PostItem, RowTitle, RowText, RowMetaBar, RowMeta };
+export { ProductList, PostList, ProductItem, ProductHeading, PostItem, RowTitle, RowText, RowMetaBar, RowMeta };


### PR DESCRIPTION
# what?
Keep each product status chip on the same line as the product name on phone widths, hugging the name instead of dropping onto a full-width row.

# why?
The mobile product grid collapsed to one column, so WORK / LIVE / OSS tags sat under the name and stretched the full width.